### PR TITLE
Issue #3047859 by amklose, jamesdixon: Replace deprecated drupal_set_…

### DIFF
--- a/modules/feeds_migrate_ui/src/Form/MigrationDeleteForm.php
+++ b/modules/feeds_migrate_ui/src/Form/MigrationDeleteForm.php
@@ -44,7 +44,7 @@ class MigrationDeleteForm extends EntityConfirmFormBase {
     $entity = $this->entity;
     $entity->delete();
 
-    drupal_set_message($this->t('@type deleted @label.', [
+    $this->messenger()->addMessage($this->t('@type deleted @label.', [
       '@type' => $entity->getEntityType()->getLabel(),
       '@label' => $entity->label(),
     ]));

--- a/src/Form/FeedsMigrateImporterDeleteForm.php
+++ b/src/Form/FeedsMigrateImporterDeleteForm.php
@@ -44,7 +44,7 @@ class FeedsMigrateImporterDeleteForm extends EntityConfirmFormBase {
     $entity = $this->entity;
     $entity->delete();
 
-    drupal_set_message($this->t('@type deleted @label.', [
+    $this->messenger()->addMessage($this->t('@type deleted @label.', [
       '@type' => $entity->getEntityType()->getLabel(),
       '@label' => $entity->label(),
     ]));


### PR DESCRIPTION
…message() with \Drupal::messenger()

###Problem/Motivation
We had a couple drupal_set_message() calls in the module and best practices are to use \Drupal::messenger()

###Proposed solution
Use \Drupal::messenger()

###Example/QA
Create a migration through the admin UI and delete it. The message in notificaiton area should say that migration was deleted.

Create an importer through the admin UI and delete it. The message in notification area should say that importer was deleted.
