### PR TITLE
Dependencies

### DIFF
--- a/feeds_migrate.module
+++ b/feeds_migrate.module
@@ -138,22 +138,23 @@ function feeds_migrate_migrate_process_info_alter(array &$plugins) {
  * Implements hook_form_FORM_ID_alter().
  */
 function feeds_migrate_form_migration_delete_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  /** @var Drupal\migrate_plus\Entity\MigrationInterface $migration */
   $migration = $form_state->getBuildInfo()['callback_object']->getEntity();
   // See which feeds migrate importers use this migration.
-  $num_feeds_migrate_importer_dependencies = 0;
+  $dependency_count = 0;
   /** @var \Drupal\Core\Config\ConfigManagerInterface $config_manager */
   $config_manager = \Drupal::service('config.manager');
   $dependents = $config_manager->findConfigEntityDependentsAsEntities('config', [$migration->getConfigDependencyName()]);
   foreach ($dependents as $dependent) {
     if ($dependent->getEntityType()->id() == 'feeds_migrate_importer') {
-      $num_feeds_migrate_importer_dependencies++;
+      $dependency_count++;
     }
   }
-  // If there are any dependent imports, don't allow the delte.
-  if ($num_feeds_migrate_importer_dependencies) {
+  // If there are any dependent imports, don't allow the delete.
+  if ($dependency_count) {
     $form = [];
     $caption = '<p>' . \Drupal::translation()
-        ->formatPlural($num_feeds_migrate_importer_dependencies, '%type is used by 1 feeds migrate importer on your site. You can not remove this migration until you have removed the feeds migrate importer that uses this migration.', '%type is used by @count feeds migrate importers on your site. You can not remove this migration until you have removed the feeds migrate importers that use this migration.', ['%type' => $migration->label()]) . '</p>';
+        ->formatPlural($dependency_count, '%type is used by 1 feeds migrate importer on your site. You can not remove this migration until you have removed the feeds migrate importer that uses this migration.', '%type is used by @count feeds migrate importers on your site. You can not remove this migration until you have removed the feeds migrate importers that use this migration.', ['%type' => $migration->label()]) . '</p>';
     $form['description'] = ['#markup' => $caption];
   }
 }

--- a/feeds_migrate.module
+++ b/feeds_migrate.module
@@ -5,6 +5,7 @@
  * feeds_migrate.module
  */
 
+use Drupal\Core\Config\Entity\ConfigDependencyManager;
 use Drupal\feeds_migrate\Entity\FeedsMigrateImporter;
 use Drupal\migrate\Plugin\migrate\destination\EntityContentBase;
 
@@ -130,5 +131,29 @@ function feeds_migrate_migrate_process_info_alter(array &$plugins) {
     if ($parent_plugin_id && $type && array_key_exists($parent_plugin_id, $plugins)) {
       $plugins[$parent_plugin_id]['feeds_migrate']['form'][$type] = $form_plugin['id'];
     }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function feeds_migrate_form_migration_delete_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $migration = $form_state->getBuildInfo()['callback_object']->getEntity();
+  // See which feeds migrate importers use this migration.
+  $num_feeds_migrate_importer_dependencies = 0;
+  /** @var \Drupal\Core\Config\ConfigManagerInterface $config_manager */
+  $config_manager = \Drupal::service('config.manager');
+  $dependents = $config_manager->findConfigEntityDependentsAsEntities('config', [$migration->getConfigDependencyName()]);
+  foreach ($dependents as $dependent) {
+    if ($dependent->getEntityType()->id() == 'feeds_migrate_importer') {
+      $num_feeds_migrate_importer_dependencies++;
+    }
+  }
+  // If there are any dependent imports, don't allow the delte.
+  if ($num_feeds_migrate_importer_dependencies) {
+    $form = [];
+    $caption = '<p>' . \Drupal::translation()
+        ->formatPlural($num_feeds_migrate_importer_dependencies, '%type is used by 1 feeds migrate importer on your site. You can not remove this migration until you have removed the feeds migrate importer that uses this migration.', '%type is used by @count feeds migrate importers on your site. You can not remove this migration until you have removed the feeds migrate importers that use this migration.', ['%type' => $migration->label()]) . '</p>';
+    $form['description'] = ['#markup' => $caption];
   }
 }

--- a/src/Entity/FeedsMigrateImporter.php
+++ b/src/Entity/FeedsMigrateImporter.php
@@ -212,7 +212,11 @@ class FeedsMigrateImporter extends ConfigEntityBase implements FeedsMigrateImpor
    */
   public function calculateDependencies() {
     $dependencies = parent::calculateDependencies();
-    // TODO add dependency on migration entity.
+    if ($this->originalMigration) {
+      // We should be able to use calculatePluginDependencies() here, but our
+      // migration plugin doesn't have a provider, so it falls apart.
+      $this->addDependency($this->originalMigration->getConfigDependencyKey(), $this->originalMigration->getConfigDependencyName());
+    }
     return $dependencies;
   }
 


### PR DESCRIPTION
### Problem/Motivation
Tell us why you opened this PR?

We needed to enforce dependencies so that we couldn't delete a migration with a dependent importer.

### Proposed solution
Clear explanation of what your solution looks like, the nitty gritty. 

This PR calculates the importer dependencies, which prevents config delete, and adds a check for the migrate delete confirmation form to prevent a form delete. This is the same sort of logic used to prevent deletion of a content type if there are nodes present of that type.

### Example/QA
How can reviewers easily test your code?
Create a migration and an importer per the instructions on the importer branch. Then try to delete the migration. It should prevent you from deleting the migration.
Then do a config export. Delete the config file for the migration, then import the config. It should prevent you from importing the config.

### Problems
I can't run functional tests in my current environment, so there aren't any. :(